### PR TITLE
Add containerized build using go-toolset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM registry.access.redhat.com/ubi8/ubi AS build
-WORKDIR /go/src/app
-RUN yum -y install golang make
-COPY . .
-RUN make
-
-FROM scratch
-COPY --from=build /go/src/app/routes-controller .
-ENTRYPOINT ["/routes-controller"]

--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ lint:
 
 .PHONY: image
 image:
-	${CONTAINER_RUNTIME} build -t quay.io/crcont/routes-controller:$(TAG) .
+	${CONTAINER_RUNTIME} build -t quay.io/crcont/routes-controller:$(TAG) -f images .

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi8/go-toolset:1.14.12 AS build
+WORKDIR $APP_ROOT/src
+COPY . .
+RUN make
+
+FROM scratch
+COPY --from=build /opt/app-root/src/routes-controller .
+ENTRYPOINT ["/routes-controller"]


### PR DESCRIPTION
Swicth to using the go-toolset build images to pin to a specific version of golang