### PR TITLE
image: Switch to CentOS Stream 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ lint:
 
 .PHONY: image
 image:
-	${CONTAINER_RUNTIME} build -t quay.io/crcont/routes-controller:$(TAG) -f images .
+	${CONTAINER_RUNTIME} build -t quay.io/crcont/routes-controller:$(TAG) -f images/Dockerfile .

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,8 +1,9 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.15.14 AS build
+FROM quay.io/centos/centos:stream9 AS build
 WORKDIR $APP_ROOT/src
+RUN yum -y install golang
 COPY . .
 RUN make
 
-FROM registry.access.redhat.com/ubi8/ubi
-COPY --from=build /opt/app-root/src/routes-controller .
+FROM quay.io/centos/centos:stream9
+COPY --from=build /src/routes-controller .
 ENTRYPOINT ["/routes-controller"]


### PR DESCRIPTION
The ubi8 image we were using so far does not have a recent enough golang
version. This commit changes it to CentOS Stream 9 instead which has
golang 1.18.
This fixes a small issue with the `make image` target along the way.